### PR TITLE
fix: consider all delegation strategies

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -75,9 +75,16 @@ async function getScores(
       `${SCORE_API_URL}/api/scores`
     );
 
+    const totalScores = result.reduce((acc, scores) => {
+      for (const [delegate, score] of Object.entries(scores)) {
+        acc[delegate] = (acc[delegate] ?? 0) + score;
+      }
+      return acc;
+    }, {});
+
     scores = {
       ...scores,
-      ...result[0]
+      ...totalScores
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/snapshot-labs/workflow/issues/306

- Previously we consider only first delegation strategy, this is resulting in wrong voting power in delegates page


## How to test

- Try this query 
```GraphQL
query ($first: Int!, $skip: Int!, $orderBy: Delegate_orderBy!, $orderDirection: OrderDirection!, $governance: String!) {
  delegates(
    first: $first
    skip: $skip
    orderBy: $orderBy
    orderDirection: $orderDirection
    where: {tokenHoldersRepresentedAmount_gte: 0, governance: $governance}
  ) {
    id
    user
    delegatedVotes
    delegatedVotesRaw
    tokenHoldersRepresentedAmount
  }
  governance(id: $governance) {
    delegatedVotes
    totalDelegates
  }
}
```
variable
```json
{
  "orderBy": "delegatedVotes",
  "orderDirection": "desc",
  "skip": 0,
  "first": 40,
  "governance": "sandboxdao.eth"
}
```

Notice that top delegates voting power increase as we now consider all strategies

