### PR TITLE
fix: use checksum addresses in delegations

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -37,11 +37,17 @@ async function getNetworkDelegations(network: string) {
     return cache.data;
   }
 
-  const delegations = await snapshotjs.utils.getDelegatesBySpace(
+  const delegationsData = await snapshotjs.utils.getDelegatesBySpace(
     network,
     null,
     'latest'
   );
+
+  const delegations = delegationsData.map(delegation => ({
+    ...delegation,
+    delegate: snapshotjs.utils.getFormattedAddress(delegation.delegate, 'evm'),
+    delegator: snapshotjs.utils.getFormattedAddress(delegation.delegator, 'evm')
+  }));
 
   networkDelegationsCache.set(network, {
     timestamp: now,


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/delegate-registry-api/issues/7

- Using the checksummed address to calculate delegation voting power

## How to test

- Try this query 
```GraphQL
query ($first: Int!, $skip: Int!, $orderBy: Delegate_orderBy!, $orderDirection: OrderDirection!, $governance: String!) {
  delegates(
    first: $first
    skip: $skip
    orderBy: $orderBy
    orderDirection: $orderDirection
    where: {tokenHoldersRepresentedAmount_gte: 0, governance: $governance}
  ) {
    id
    user
    delegatedVotes
    delegatedVotesRaw
    tokenHoldersRepresentedAmount
  }
  governance(id: $governance) {
    delegatedVotes
    totalDelegates
  }
}
```
variable
```json
{
  "orderBy": "delegatedVotes",
  "orderDirection": "desc",
  "skip": 0,
  "first": 40,
  "governance": "moxie.eth"
}
```

Before the fix, it will return empty delegations. and after fix it will return delegations
