### PR TITLE
chore: Enable dependabot for snapshot related packages

### DIFF
--- a/.github/.github/dependabot.yml
+++ b/.github/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@snapshot-labs/*"
+    ignore:
+      - dependency-name: "@snapshot-labs/checkpoint"
+    groups:
+      snapshot:
+        patterns:
+        - "@snapshot-labs/*"


### PR DESCRIPTION
Same as https://github.com/snapshot-labs/sx-monorepo/blob/master/.github/dependabot.yml to update snapshot.js