### PR TITLE
chore: bump snapshot.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@apollo/client": "^3.11.4",
     "@ethersproject/units": "^5.7.0",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.39",
-    "@snapshot-labs/snapshot.js": "^0.12.7",
+    "@snapshot-labs/snapshot.js": "^0.12.36",
     "@types/node": "^18.11.6",
     "async-mutex": "^0.5.0",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,10 +612,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.18.tgz#fcbd86d4557821bff774d60e5c636ad47ed85d77"
   integrity sha512-v6tj7l19KJUWjBbsWpwxaYO2mlIDBFyAG0OMSPhUgrhltO7b6R4Ejxn2k4Qgi/NtlnOrj+3Gt3eQRry8Jfgjrg==
 
-"@snapshot-labs/snapshot.js@^0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.7.tgz#e08899984c012cb680730fa9ed785236a96ef9b3"
-  integrity sha512-pMNckn709ZTXQcdWRco7RfOKKuTbXa08BPaZA1NLq9NDiWdvOP0UAj4ZQBzmXPPOmM6vkpH7QwX9bzhobJe6yA==
+"@snapshot-labs/snapshot.js@^0.12.36":
+  version "0.12.36"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot.js/-/snapshot.js-0.12.36.tgz#89ff38be1b2ab2b239ab5caf0b20c5c4e65eed4e"
+  integrity sha512-cCwX8mLattshjMLzb731DWDQ8/D0uHINBjTNyFhdyxwW/7B1Dr4wAIQHR+iXwJDA3aiqDJPIP6llD1HRRllvBQ==
   dependencies:
     "@ensdomains/eth-ens-namehash" "^2.0.15"
     "@ethersproject/abi" "^5.6.4"
@@ -885,7 +885,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3", abi-wan-kanabi@^1.0.1, abi-wan-kanabi@^1.0.3:
+"abi-wan-kanabi-v1@npm:abi-wan-kanabi@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
   integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
@@ -904,6 +904,17 @@ abbrev@1:
     ansicolors "^0.3.2"
     cardinal "^2.1.1"
     fs-extra "^10.0.0"
+    yargs "^17.7.2"
+
+abi-wan-kanabi@^1.0.1, abi-wan-kanabi@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz#0d8607f2a2ccb2151a69debea1c3bb68b76c5aa2"
+  integrity sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==
+  dependencies:
+    abi-wan-kanabi "^1.0.1"
+    fs-extra "^10.0.0"
+    rome "^12.1.3"
+    typescript "^4.9.5"
     yargs "^17.7.2"
 
 abort-controller@^3.0.0:


### PR DESCRIPTION
This will add missing networks that prevent VP to be computed.