### PR TITLE
feat: Store currentBlock in storage table

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import Checkpoint, { LogLevel } from '@snapshot-labs/checkpoint';
+import { register } from '@snapshot-labs/checkpoint/dist/src/register';
+import config from './config.json';
+import { NoopIndexer } from './noopindexer';
+
+const dir = __dirname.endsWith('dist/src') ? '../' : '';
+const schemaFile = path.join(__dirname, `${dir}../src/schema.gql`);
+const schema = fs.readFileSync(schemaFile, 'utf8');
+const indexer = new NoopIndexer();
+
+const checkpoint = new Checkpoint(config, indexer, schema, {
+  logLevel: LogLevel.Info,
+  prettifyLogs: true
+});
+
+async function setupStorageTable() {
+  const { knex } = checkpoint.getBaseContext();
+  console.log('checking for storage table');
+
+  const storageTableExists = await knex.schema.hasTable('storage');
+  if (!storageTableExists) {
+    console.log('Creating storage table');
+    await knex.schema.createTable('storage', table => {
+      table.string('key').primary();
+      table.string('value');
+    });
+  } else {
+    console.log('Storage table already exists');
+  }
+}
+function createCurrentBlockTracker() {
+  const knex = register.getKnex();
+  let initialized = false;
+
+  const increaseCurrentBlock = async () => {
+    let current = register.getCurrentBlock();
+    if (!initialized) {
+      const storage = await knex('storage')
+        .where('key', 'currentBlock')
+        .first();
+      current = storage ? BigInt(storage.value) : 0n;
+    }
+
+    const nextValue = current + 1n;
+
+    initialized = true;
+    register.setCurrentBlock(nextValue);
+    await knex('storage')
+      .insert({
+        key: 'currentBlock',
+        value: nextValue.toString()
+      })
+      .onConflict('key')
+      .merge();
+  };
+
+  return { increaseCurrentBlock };
+}
+
+const currentBlockTracker = createCurrentBlockTracker();
+
+export { checkpoint, setupStorageTable, currentBlockTracker };

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -108,8 +108,6 @@ export async function compute(governances: string[]) {
   const release = await mutex.acquire();
 
   try {
-    await currentBlockTracker.increaseCurrentBlock();
-
     for (const governance of governances) {
       console.log('computing', governance);
 
@@ -119,7 +117,7 @@ export async function compute(governances: string[]) {
         console.log('ignoring because of recent compute');
         continue;
       }
-
+      await currentBlockTracker.increaseCurrentBlock();
       const space = await getSpace(governance);
       const delegations = await getNetworkDelegations(space.network);
 

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -1,7 +1,7 @@
 import { formatUnits } from '@ethersproject/units';
-import { register } from '@snapshot-labs/checkpoint/dist/src/register';
 import snapshotjs from '@snapshot-labs/snapshot.js';
 import { Mutex } from 'async-mutex';
+import { currentBlockTracker } from './checkpoint';
 import {
   NETWORK_COMPUTE_DELAY_SECONDS,
   SCORE_API_URL,
@@ -108,7 +108,7 @@ export async function compute(governances: string[]) {
   const release = await mutex.acquire();
 
   try {
-    register.setCurrentBlock(register.getCurrentBlock() + 1n);
+    await currentBlockTracker.increaseCurrentBlock();
 
     for (const governance of governances) {
       console.log('computing', governance);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,14 @@
 import 'dotenv/config';
-import fs from 'fs';
-import path from 'path';
-import Checkpoint, { LogLevel } from '@snapshot-labs/checkpoint';
 import cors from 'cors';
 import express from 'express';
-import config from './config.json';
+import { checkpoint, setupStorageTable } from './checkpoint';
 import { middleware } from './middleware';
-import { NoopIndexer } from './noopindexer';
-
-const dir = __dirname.endsWith('dist/src') ? '../' : '';
-const schemaFile = path.join(__dirname, `${dir}../src/schema.gql`);
-const schema = fs.readFileSync(schemaFile, 'utf8');
 
 if (process.env.CA_CERT) {
   process.env.CA_CERT = process.env.CA_CERT.replace(/\\n/g, '\n');
 }
 
-const indexer = new NoopIndexer();
-const checkpoint = new Checkpoint(config, indexer, schema, {
-  logLevel: LogLevel.Info,
-  prettifyLogs: true
-});
-
-async function run() {
-  await checkpoint.reset();
-  await checkpoint.resetMetadata();
-}
-
-run();
+setupStorageTable();
 
 const app = express();
 app.use(express.json({ limit: '4mb' }));


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/444

### Summary
- Store current block in new storage table
- Move everything to a new file to initialize before `middleware` 

### How to test
- Send a [delegate query](http://localhost:3000/?operationName=ABC&query=query%20(%24first%3A%20Int!%2C%20%24skip%3A%20Int!%2C%20%24orderBy%3A%20Delegate_orderBy!%2C%20%24orderDirection%3A%20OrderDirection!%2C%20%24where%3A%20Delegate_filter%2C%20%24governance%3A%20String!)%20%7B%0A%20%20delegates(%0A%20%20%20%20first%3A%20%24first%0A%20%20%20%20skip%3A%20%24skip%0A%20%20%20%20orderBy%3A%20%24orderBy%0A%20%20%20%20orderDirection%3A%20%24orderDirection%0A%20%20%20%20where%3A%20%24where%0A%20%20)%20%7B%0A%20%20%20%20id%0A%20%20%20%20user%0A%20%20%20%20delegatedVotes%0A%20%20%20%20delegatedVotesRaw%0A%20%20%20%20tokenHoldersRepresentedAmount%0A%20%20%7D%0A%20%20governance(id%3A%20%24governance)%20%7B%0A%20%20%20%20delegatedVotes%0A%20%20%20%20totalDelegates%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%22orderBy%22%3A%20%22delegatedVotes%22%2C%0A%20%20%22orderDirection%22%3A%20%22desc%22%2C%0A%20%20%22first%22%3A%2040%2C%0A%20%20%22skip%22%3A%200%2C%0A%20%20%22governance%22%3A%20%22beets.eth%22%2C%0A%20%20%22where%22%3A%20%7B%0A%20%20%20%20%22tokenHoldersRepresentedAmount_gte%22%3A%200%2C%0A%20%20%20%20%22governance%22%3A%20%22beets.eth%22%0A%20%20%7D%0A%7D)
- Restart Server
- Server should return data from cache

### Todo
- [ ] Store current block or reset everything on prod DB