### PR TITLE
fix: remove old delegates before writing new ones

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -54,6 +54,8 @@ function createCurrentBlockTracker() {
       })
       .onConflict('key')
       .merge();
+
+    return nextValue;
   };
 
   return { increaseCurrentBlock };


### PR DESCRIPTION
Because we do not write all delegates, only those that have some votes if delegate has all of its delegations removed it would not be reflected by the indexer.

To avoid this before we update delegates that we know have some score we delete all other delegates - this means all delegates that lost VP will be removed from the list.

## Test plan

1. Have some address that doesn't have delegations.
2. Delegate your VP to that address so it has some VP now [here](https://snapshot.box/#/s:gnosis.eth/delegates).
3. Run following query. You see correct VP.
4. Undelegate from that address (so user has no delegated VP anymore).
5. Restart API (so there is no delay between computations).
6. Run this query again - you see VP still, but it's because it's old data before computation happens in the background.
7. Wait for computation to finish.
8. Run this query again - now this delegate is gone.

```gql
{
  delegates(where:{governance:"gnosis.eth", user: "address"}) {
    id
    delegatedVotes
  }
}
```