### PR TITLE
feat: add ApeChain delegation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
     "@apollo/client": "^3.11.4",
+    "@ethersproject/abi": "^5.8.0",
+    "@ethersproject/contracts": "^5.8.0",
     "@ethersproject/providers": "^5.8.0",
     "@ethersproject/strings": "^5.8.0",
     "@ethersproject/units": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
     "@apollo/client": "^3.11.4",
+    "@ethersproject/providers": "^5.8.0",
+    "@ethersproject/strings": "^5.8.0",
     "@ethersproject/units": "^5.7.0",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.39",
     "@snapshot-labs/snapshot.js": "^0.12.49",

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -8,12 +8,27 @@ import {
   SCORE_API_URL,
   SPACE_COMPUTE_DELAY_SECONDS
 } from './constants';
+import {
+  getCustomGovernanceDelegations,
+  getOnchainScores
+} from './custom-governances';
 import { getSpace, Space } from './hub';
+import { CustomGovernance, DelegateItem } from './types';
 import { Delegate, Governance } from '../.checkpoint/models';
 
 type NetworkCache = {
   timestamp: number;
   data: Awaited<ReturnType<typeof snapshotjs.utils.getDelegatesBySpace>>;
+};
+
+const CUSTOM_GOVERNANCES: Record<string, CustomGovernance | undefined> = {
+  curtis: {
+    type: 'CUSTOM_GOVERNANCE',
+    network: '33111',
+    viewId: '',
+    subgraphUrl:
+      'https://api.goldsky.com/api/public/project_cmb7mtyozekvj01q7bo0bcirq/subgraphs/sekhmet-snapshot-subgraph-curtis/0.0.2/gn'
+  }
 };
 
 const DECIMALS = 18;
@@ -29,6 +44,23 @@ const DELEGATION_STRATEGIES = [
 const networkDelegationsCache = new Map<string, NetworkCache>();
 const lastSpaceCompute = new Map<string, number>();
 const mutex = new Mutex();
+
+function getDelegationSpace(id: string) {
+  if (id.includes(':')) {
+    const [networkId, viewId] = id.split(':');
+
+    if (CUSTOM_GOVERNANCES[networkId]) {
+      return {
+        ...CUSTOM_GOVERNANCES[networkId],
+        viewId
+      };
+    }
+
+    throw new Error(`Unknown custom governance ID: ${id}`);
+  }
+
+  return getSpace(id);
+}
 
 async function getNetworkDelegations(network: string) {
   const cache = networkDelegationsCache.get(network);
@@ -119,8 +151,12 @@ export async function compute(governances: string[]) {
         continue;
       }
       const current = await currentBlockTracker.increaseCurrentBlock();
-      const space = await getSpace(governance);
-      const delegations = await getNetworkDelegations(space.network);
+      const space = await getDelegationSpace(governance);
+      const isCustomGovernance = 'type' in space;
+
+      const delegations = isCustomGovernance
+        ? await getCustomGovernanceDelegations(space)
+        : await getNetworkDelegations(space.network);
 
       const delegatorCounter = {};
       for (const delegation of delegations) {
@@ -137,23 +173,33 @@ export async function compute(governances: string[]) {
       const delegatesAddresses = Object.keys(delegationsMap);
       const uniqueDelegates = Object.values(delegationsMap);
 
-      const strategies = space.strategies.filter(strategy =>
-        DELEGATION_STRATEGIES.includes(strategy.name)
-      );
+      let delegates: DelegateItem[] = [];
+      if (isCustomGovernance) {
+        const scores = await getOnchainScores(space.network, delegations);
 
-      const scores = await getScores(
-        space.network,
-        governance,
-        strategies,
-        delegatesAddresses
-      );
+        delegates = uniqueDelegates.map(delegate => ({
+          ...delegate,
+          score: scores[delegate.delegate] ?? 0n
+        }));
+      } else {
+        const strategies = space.strategies.filter(strategy =>
+          DELEGATION_STRATEGIES.includes(strategy.name)
+        );
 
-      const delegates = uniqueDelegates.map(delegate => ({
-        ...delegate,
-        score: BigInt(
-          Math.floor((scores[delegate.delegate] ?? 0) * 10 ** DECIMALS)
-        )
-      }));
+        const scores = await getScores(
+          space.network,
+          governance,
+          strategies,
+          delegatesAddresses
+        );
+
+        delegates = uniqueDelegates.map(delegate => ({
+          ...delegate,
+          score: BigInt(
+            Math.floor((scores[delegate.delegate] ?? 0) * 10 ** DECIMALS)
+          )
+        }));
+      }
 
       const sortedDelegates = delegates
         .filter(delegate => delegate.score > 0n)

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -26,6 +26,7 @@ const CUSTOM_GOVERNANCES: Record<string, CustomGovernance | undefined> = {
     type: 'CUSTOM_GOVERNANCE',
     network: '33111',
     viewId: '',
+    delegationRegistry: '0xdd6b74123b2ab93ad701320d3f8d1b92b4fa5202',
     subgraphUrl:
       'https://api.goldsky.com/api/public/project_cmb7mtyozekvj01q7bo0bcirq/subgraphs/sekhmet-snapshot-subgraph-curtis/0.0.2/gn'
   }
@@ -175,7 +176,10 @@ export async function compute(governances: string[]) {
 
       let delegates: DelegateItem[] = [];
       if (isCustomGovernance) {
-        const scores = await getOnchainScores(space.network, delegations);
+        const scores = await getOnchainScores({
+          space,
+          delegations
+        });
 
         delegates = uniqueDelegates.map(delegate => ({
           ...delegate,

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -22,13 +22,21 @@ type NetworkCache = {
 };
 
 const CUSTOM_GOVERNANCES: Record<string, CustomGovernance | undefined> = {
+  apechain: {
+    type: 'CUSTOM_GOVERNANCE',
+    network: '33139',
+    viewId: '',
+    delegationRegistry: '0x2f9e24e272d343c1f833ee7f3c6d6abc689b0102',
+    subgraphUrl:
+      'https://api.goldsky.com/api/public/project_cmb7myliieemg01v8928cd8rs/subgraphs/snapshot-apechain/0.0.1/gn'
+  },
   curtis: {
     type: 'CUSTOM_GOVERNANCE',
     network: '33111',
     viewId: '',
     delegationRegistry: '0xdd6b74123b2ab93ad701320d3f8d1b92b4fa5202',
     subgraphUrl:
-      'https://api.goldsky.com/api/public/project_cmb7mtyozekvj01q7bo0bcirq/subgraphs/sekhmet-snapshot-subgraph-curtis/0.0.2/gn'
+      'https://api.goldsky.com/api/public/project_cmb7myliieemg01v8928cd8rs/subgraphs/snapshot-curtis/0.0.1/gn'
   }
 };
 

--- a/src/custom-governances.ts
+++ b/src/custom-governances.ts
@@ -1,0 +1,124 @@
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import snapshotjs from '@snapshot-labs/snapshot.js';
+import { CustomGovernance, Delegation } from './types';
+
+const PAGE_SIZE = 1000;
+
+function getProvider(chainId: string) {
+  return new StaticJsonRpcProvider(
+    `https://rpc.snapshot.org/${chainId}`,
+    Number(chainId)
+  );
+}
+
+export async function getOnchainScores(
+  chainId: string,
+  delegations: Delegation[]
+) {
+  const provider = getProvider(chainId);
+
+  const scores: Record<string, bigint> = {};
+
+  for (const delegation of delegations) {
+    const { delegator, delegate } = delegation;
+
+    if (!scores[delegate]) {
+      const balance = await provider.getBalance(delegate);
+      scores[delegate] = balance.toBigInt();
+    }
+
+    const balance = await provider.getBalance(delegator);
+    scores[delegate] += balance.toBigInt();
+  }
+
+  return scores;
+}
+
+// Adapted from https://github.com/snapshot-labs/snapshot.js/blob/55e4c1c7a33ce28dd465c42c026814047c39bb3c/src/utils/delegation.ts#L14
+// But uses space_raw instead of space_in
+export async function getCustomGovernanceDelegations(space: CustomGovernance) {
+  let pivot = 0;
+  const result = new Map<string, Delegation>();
+
+  while (true) {
+    const newResults = await fetchData({
+      url: space.subgraphUrl,
+      spaceRaw: space.viewId,
+      pivot,
+      snapshot: 'latest'
+    });
+
+    if (checkAllDuplicates(newResults)) {
+      throw new Error('Unable to paginate delegation');
+    }
+
+    newResults.forEach(delegation => {
+      concatUniqueDelegation(result, delegation);
+      pivot = delegation.timestamp;
+    });
+
+    if (newResults.length < PAGE_SIZE) break;
+  }
+
+  return [...result.values()];
+}
+
+function checkAllDuplicates(delegations: Delegation[]) {
+  return (
+    delegations.length === PAGE_SIZE &&
+    delegations[0].timestamp === delegations[delegations.length - 1].timestamp
+  );
+}
+
+function delegationKey(delegation: Delegation) {
+  return `${delegation.delegator}-${delegation.delegate}-${delegation.space}`;
+}
+
+function concatUniqueDelegation(
+  result: Map<string, Delegation>,
+  delegation: Delegation
+): void {
+  const key = delegationKey(delegation);
+  if (!result.has(key)) {
+    result.set(key, delegation);
+  }
+}
+
+async function fetchData({
+  url,
+  spaceRaw,
+  pivot,
+  snapshot
+}: {
+  url: string;
+  spaceRaw: string;
+  pivot: number;
+  snapshot: string | number;
+}): Promise<Delegation[]> {
+  const params: any = {
+    delegations: {
+      __args: {
+        where: {
+          timestamp_gte: pivot,
+          space_raw: spaceRaw
+        },
+        first: PAGE_SIZE,
+        skip: 0,
+        orderBy: 'timestamp',
+        orderDirection: 'asc'
+      },
+      delegator: true,
+      space: true,
+      delegate: true,
+      timestamp: true
+    }
+  };
+
+  if (snapshot !== 'latest') {
+    params.delegations.__args.block = { number: snapshot };
+  }
+
+  return (
+    (await snapshotjs.utils.subgraphRequest(url, params)).delegations || []
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,5 +10,6 @@ export type CustomGovernance = {
   type: 'CUSTOM_GOVERNANCE';
   network: string;
   viewId: string;
+  delegationRegistry: string;
   subgraphUrl: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+import snapshotjs from '@snapshot-labs/snapshot.js';
+
+export type Delegation = Awaited<
+  ReturnType<typeof snapshotjs.utils.getDelegatesBySpace>
+>[number];
+
+export type DelegateItem = Delegation & { score: bigint };
+
+export type CustomGovernance = {
+  type: 'CUSTOM_GOVERNANCE';
+  network: string;
+  viewId: string;
+  subgraphUrl: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,19 @@
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/web" "^5.7.0"
 
+"@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+
 "@ethersproject/abstract-signer@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
@@ -104,6 +117,17 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/address@^5.6.1", "@ethersproject/address@^5.7.0":
   version "5.7.0"
@@ -116,12 +140,30 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
 
+"@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+
 "@ethersproject/base64@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
   integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
 
 "@ethersproject/basex@^5.7.0":
   version "5.7.0"
@@ -130,6 +172,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/basex@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.8.0.tgz#1d279a90c4be84d1c1139114a1f844869e57d03a"
+  integrity sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
 "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
@@ -140,6 +190,15 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@^5.6.1", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
@@ -147,12 +206,26 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/constants@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
   integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.8.0"
 
 "@ethersproject/contracts@^5.6.2":
   version "5.7.0"
@@ -184,6 +257,21 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/hdnode@^5.7.0":
   version "5.7.0"
@@ -230,10 +318,23 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
 "@ethersproject/networks@^5.7.0":
   version "5.7.1"
@@ -241,6 +342,13 @@
   integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/pbkdf2@^5.7.0":
   version "5.7.0"
@@ -256,6 +364,13 @@
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
+  dependencies:
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/providers@^5.6.8", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
@@ -283,6 +398,32 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.8.0.tgz#6c2ae354f7f96ee150439f7de06236928bc04cb4"
+  integrity sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/basex" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/random" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/sha2" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
+    bech32 "1.1.4"
+    ws "8.18.0"
+
 "@ethersproject/random@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
@@ -290,6 +431,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/random@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.8.0.tgz#1bced04d49449f37c6437c701735a1a022f0057a"
+  integrity sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/rlp@^5.7.0":
   version "5.7.0"
@@ -299,6 +448,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+
 "@ethersproject/sha2@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
@@ -306,6 +463,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.8.0.tgz#8954a613bb78dac9b46829c0a95de561ef74e5e1"
+  integrity sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@^5.7.0":
@@ -320,6 +486,18 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    bn.js "^5.2.1"
+    elliptic "6.6.1"
+    hash.js "1.1.7"
+
 "@ethersproject/strings@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
@@ -328,6 +506,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
+  dependencies:
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
 "@ethersproject/transactions@^5.7.0":
   version "5.7.0"
@@ -343,6 +530,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/rlp" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
+
+"@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
 
 "@ethersproject/units@^5.7.0":
   version "5.7.0"
@@ -384,6 +586,17 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
+  dependencies:
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@ethersproject/wordlists@^5.7.0":
   version "5.7.0"
@@ -1430,6 +1643,19 @@ elliptic@6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
+elliptic@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -3894,6 +4120,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xtend@^4.0.0:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,21 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@ethersproject/abi@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
+  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
+  dependencies:
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
+
 "@ethersproject/abstract-provider@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
@@ -242,6 +257,22 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
+
+"@ethersproject/contracts@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.8.0.tgz#243a38a2e4aa3e757215ea64e276f8a8c9d8ed73"
+  integrity sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==
+  dependencies:
+    "@ethersproject/abi" "^5.8.0"
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
 
 "@ethersproject/hash@^5.7.0":
   version "5.7.0"


### PR DESCRIPTION
This PR adds ApeChain delegation, it uses the same API, but uses special prefix for governances (currently supported is `curtis:`).

When requesting custom governance specified subgraph is used and delegated balance is used for all delegatees.

## Test plan

1. Run locally.
2. Run following query (twice with some delay to let it compute).
3. You see results.

```gql
{
  delegates(where: {governance: "curtis:0x0000000000000000000000000000000000000000000000000000000000000001"}) {
    id
    delegatedVotes
    delegatedVotesRaw
  }
  governance(id:"curtis:0x0000000000000000000000000000000000000000000000000000000000000001") {
    id
    totalDelegates
    currentDelegates
    delegatedVotes
    delegatedVotesRaw
  }
}

```