### PR TITLE
fix: consider all delegation networks and only space related delegations for delegators count

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -163,9 +163,13 @@ export async function compute(governances: string[]) {
       const space = await getDelegationSpace(governance);
       const isCustomGovernance = 'type' in space;
 
-      const delegations = isCustomGovernance
+      const allDelegations = isCustomGovernance
         ? await getCustomGovernanceDelegations(space)
         : await getNetworkDelegations(space.network);
+
+      const delegations = allDelegations.filter(delegation =>
+        ['', governance].includes(delegation.space)
+      );
 
       const delegatorCounter = {};
       for (const delegation of delegations) {

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -71,8 +71,8 @@ function getDelegationSpace(id: string) {
   return getSpace(id);
 }
 
-async function fetchCachedDelegations(space: Space) {
-  const cache = networkDelegationsCache.get(space.network);
+async function getNetworkDelegations(network: string) {
+  const cache = networkDelegationsCache.get(network);
   const now = Math.floor(Date.now() / 1000);
 
   if (cache && now - cache.timestamp < NETWORK_COMPUTE_DELAY_SECONDS) {
@@ -80,8 +80,8 @@ async function fetchCachedDelegations(space: Space) {
   }
 
   const delegationsData = await snapshotjs.utils.getDelegatesBySpace(
-    space.network,
-    space.id,
+    network,
+    null,
     'latest'
   );
 
@@ -91,7 +91,7 @@ async function fetchCachedDelegations(space: Space) {
     delegator: snapshotjs.utils.getFormattedAddress(delegation.delegator, 'evm')
   }));
 
-  networkDelegationsCache.set(space.network, {
+  networkDelegationsCache.set(network, {
     timestamp: now,
     data: delegations
   });
@@ -165,7 +165,7 @@ export async function compute(governances: string[]) {
 
       const allDelegations = isCustomGovernance
         ? await getCustomGovernanceDelegations(space)
-        : await fetchCachedDelegations(space);
+        : await getNetworkDelegations(space.network);
 
       const delegations = allDelegations.filter(delegation =>
         ['', governance].includes(delegation.space)

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -13,7 +13,7 @@ import {
   getOnchainScores
 } from './custom-governances';
 import { getSpace, Space } from './hub';
-import { CustomGovernance, DelegateItem } from './types';
+import { CustomGovernance, DelegateItem, Delegation } from './types';
 import { Delegate, Governance } from '../.checkpoint/models';
 
 type NetworkCache = {
@@ -214,7 +214,7 @@ export async function compute(governances: string[]) {
           delegations
         });
 
-        delegates = uniqueDelegates.map((delegate: any) => ({
+        delegates = uniqueDelegates.map(delegate => ({
           ...delegate,
           score: scores[delegate.delegate] ?? 0n
         }));
@@ -230,7 +230,7 @@ export async function compute(governances: string[]) {
           delegatesAddresses
         );
 
-        delegates = uniqueDelegates.map((delegate: any) => ({
+        delegates = uniqueDelegates.map(delegate => ({
           ...delegate,
           score: BigInt(
             Math.floor((scores[delegate.delegate] ?? 0) * 10 ** DECIMALS)

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -82,7 +82,7 @@ async function getDelegationsForNetworks(space: Space) {
   );
 
   const now = Math.floor(Date.now() / 1000);
-  let allDelegations: any[] = [];
+  let allDelegations: Delegation[] = [];
 
   for (const network of delegationNetworks) {
     const cache = networkDelegationsCache.get(network);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,5 +17,5 @@ app.use(cors({ maxAge: 86400 }));
 app.use(middleware);
 app.use('/', checkpoint.graphql);
 
-const PORT = process.env.PORT ?? 3000;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/workflow/issues/584
Fixes https://github.com/snapshot-labs/sx-monorepo/issues/1400

### Summary
- We now consider all delegation networks to get delegations
- Now we filter counts with global delegations and space delegations

### How to test
- Run `yarn dev`
- Go to http://localhost:3000
- Test with query:
```GraphQL
query ($first: Int!, $skip: Int!, $orderBy: Delegate_orderBy!, $orderDirection: OrderDirection!, $where: Delegate_filter, $governance: String!) {
  delegates(
    first: $first
    skip: $skip
    orderBy: $orderBy
    orderDirection: $orderDirection
    where: $where
  ) {
    id
    user
    delegatedVotes
    delegatedVotesRaw
    tokenHoldersRepresentedAmount
  }
  governance(id: $governance) {
    delegatedVotes
    totalDelegates
  }
}
```

Variables:
```JSON
{
  "orderBy": "tokenHoldersRepresentedAmount",
  "orderDirection": "desc",
  "first": 40,
  "skip": 0,
  "governance": "cow.eth",
  "where": {
    "tokenHoldersRepresentedAmount_gte": 0,
    "governance": "cow.eth"

  }
}
```
- You should see much less voting power and delegators counts
- spaces like `stgdao.eth` should get delegations only from mainnet network