### PR TITLE
fix: filter strategies to include only delegation strategies

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -72,13 +72,19 @@ function getDelegationSpace(id: string) {
 }
 
 async function getDelegationsForNetworks(space: Space) {
+  const strategies = space.strategies.filter(strategy =>
+    DELEGATION_STRATEGIES.includes(strategy.name)
+  );
+
   const delegationNetworks = Array.from(
-    new Set([
-      space.network,
-      ...(space.strategies.map(
-        s => s.params.delegationNetwork ?? s.network ?? space.network
-      ) ?? [])
-    ])
+    new Set(
+      strategies.map(
+        strategy =>
+          strategy.params?.delegationNetwork ??
+          strategy.network ??
+          space.network
+      )
+    )
   );
 
   const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
Regression from https://github.com/snapshot-labs/delegate-registry-api/pull/34

### Summary
- Filter strategies to include only valid delegation strategies
- Simplify mapping logic


### How to test:
```bash
curl --location 'http://localhost:3000' \
--header 'accept: */*' \
--data '{"query":"query ($first: Int!, $skip: Int!, $orderBy: Delegate_orderBy!, $orderDirection: OrderDirection!, $where: Delegate_filter, $governance: String!) {\n  delegates(\n    first: $first\n    skip: $skip\n    orderBy: $orderBy\n    orderDirection: $orderDirection\n    where: $where\n  ) {\n    id\n    user\n    delegatedVotes\n    delegatedVotesRaw\n    tokenHoldersRepresentedAmount\n  }\n  governance(id: $governance) {\n    delegatedVotes\n    totalDelegates\n  }\n}","variables":{"orderBy":"delegatedVotes","orderDirection":"desc","first":40,"skip":0,"governance":"stakersunion.eth","where":{"tokenHoldersRepresentedAmount_gte":0,"governance":"stakersunion.eth"}}}'
```

You should see `7` delegations instead of `8`
