### PR TITLE
feat: support whitelisted delegates

### DIFF
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -93,7 +93,7 @@ function getWhitelistedAddresses(space: Space): string[] {
         WHITELIST_DELEGATES_STRATEGIES.includes(strategy.name) &&
         strategy.params?.whitelistedDelegates?.length > 0
     )
-    .flatMap(strategy => strategy.params.whitelistedDelegates)
+    .flatMap(strategy => strategy.params?.whitelistedDelegates ?? [])
     .map(address => snapshotjs.utils.getFormattedAddress(address, 'evm'));
 }
 


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/workflow/issues/643

### Summary
- We now support whitelisted delegates
- If a space has `spark-with-delegation` and `whiltelistedDelegates` param, we filter existing delegations and add `0` score delegations for whitelisted delegates
- Return whitelisted delegates even if these addresses doesn't have any voting power
- Modify the counts/totals to ignore the `0` score delegations that we added

### How to test
- Run `yarn dev`
- [Use this query ](http://localhost:3000/graphql?query=query%20(%24first%3A%20Int!%2C%20%24skip%3A%20Int!%2C%20%24orderBy%3A%20Delegate_orderBy!%2C%20%24orderDirection%3A%20OrderDirection!%2C%20%24where%3A%20Delegate_filter%2C%20%24governance%3A%20String!)%20%7B%0A%20%20delegates(first%3A%20%24first%2C%20skip%3A%20%24skip%2C%20orderBy%3A%20%24orderBy%2C%20orderDirection%3A%20%24orderDirection%2C%20where%3A%20%24where)%20%7B%0A%20%20%20%20id%0A%20%20%20%20user%0A%20%20%20%20delegatedVotes%0A%20%20%20%20delegatedVotesRaw%0A%20%20%20%20tokenHoldersRepresentedAmount%0A%20%20%7D%0A%20%20governance(id%3A%20%24governance)%20%7B%0A%20%20%20%20delegatedVotes%0A%20%20%20%20totalDelegates%0A%20%20%20%20currentDelegates%0A%20%20%7D%0A%7D%0A&variables=%7B%0A%20%20%22orderBy%22%3A%20%22delegatedVotes%22%2C%0A%20%20%22orderDirection%22%3A%20%22desc%22%2C%0A%20%20%22first%22%3A%2040%2C%0A%20%20%22skip%22%3A%200%2C%0A%20%20%22governance%22%3A%20%22sparkfi.eth%22%2C%0A%20%20%22where%22%3A%20%7B%0A%20%20%20%20%22tokenHoldersRepresentedAmount_gte%22%3A%200%2C%0A%20%20%20%20%22governance%22%3A%20%22sparkfi.eth%22%0A%20%20%7D%0A%7D)
- wait for the compute
- Add whitelist addresses to test the `0` voting power case
```bash
diff --git a/src/compute.ts b/src/compute.ts
index dc9190d..f5bb88e 100644
--- a/src/compute.ts
+++ b/src/compute.ts
@@ -245,6 +245,11 @@ export async function compute(governances: string[]) {
         ? []
         : getWhitelistedAddresses(space);
 
+      whitelistedAddresses.push(
+        '0x89446aF03652c5257dB5C8E4E85495EB754196c5',
+        '0x1234567890abcdef1234567890abcdef12345678'
+      );
+
       if (whitelistedAddresses.length > 0) {
         // filter and add delegations with whitelisted addresses
         delegations = filterDelegationsByWhitelist(
```
- Run the same query as above, the whitelist addresses should still show up in result