### PR TITLE
fix: disable ApolloClient cache

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -27,7 +27,12 @@ export type Space = {
 
 const client = new ApolloClient({
   uri: `${HUB_URL}/graphql`,
-  cache: new InMemoryCache()
+  cache: new InMemoryCache(),
+  defaultOptions: {
+    query: {
+      fetchPolicy: 'no-cache'
+    }
+  }
 });
 
 export async function getSpace(space: string): Promise<Space> {


### PR DESCRIPTION
Previously we used built-in cache for Apollo which meant that all space data was cached forever (it's invalidated by Apollo's mutations but we don't use those here).

This was mostly issue when space changes its settings.

Closes: https://github.com/snapshot-labs/delegate-registry-api/issues/39
