### PR TITLE
fix: prevent delegates query timeout (524)

### DIFF
--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -30,6 +30,25 @@ async function setupStorageTable() {
     console.log('Storage table already exists');
   }
 }
+
+// Checkpoint only indexes individual scalar columns; nothing covers the
+// `upper_inf(block_range)` "current row" filter. Each hourly compute closes the
+// previous row versions and inserts new ones, so the (global) delegatedVotes
+// index fills with closed rows from every governance. Ordered delegate queries
+// then scan past those millions of dead entries and time out. This partial
+// index holds only live rows, pre-sorted for the default delegate ordering, so
+// queries never touch the bloated full-column index.
+async function ensureIndexes() {
+  const { knex } = checkpoint.getBaseContext();
+
+  if (!(await knex.schema.hasTable('delegates'))) return;
+
+  await knex.raw(
+    `CREATE INDEX IF NOT EXISTS delegates_live_gov_votes
+     ON delegates (governance, "delegatedVotes" DESC)
+     WHERE upper_inf(block_range)`
+  );
+}
 function createCurrentBlockTracker() {
   const knex = register.getKnex();
   let initialized = false;
@@ -63,4 +82,4 @@ function createCurrentBlockTracker() {
 
 const currentBlockTracker = createCurrentBlockTracker();
 
-export { checkpoint, setupStorageTable, currentBlockTracker };
+export { checkpoint, setupStorageTable, ensureIndexes, currentBlockTracker };

--- a/src/compute.ts
+++ b/src/compute.ts
@@ -351,6 +351,15 @@ export async function compute(governances: string[]) {
         await delegateEntity.save();
       }
 
+      // The API only ever reads current rows (upper_inf(block_range)), but each
+      // compute closes the previous versions and inserts new ones. Drop the now
+      // closed versions so the table doesn't accumulate unbounded dead rows.
+      await knex
+        .table(Delegate.tableName)
+        .where('governance', governance)
+        .andWhereRaw('not upper_inf(block_range)')
+        .del();
+
       lastSpaceCompute.set(governance, now);
 
       console.log('finished compute', governance);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import cors from 'cors';
 import express from 'express';
-import { checkpoint, setupStorageTable } from './checkpoint';
+import { checkpoint, ensureIndexes, setupStorageTable } from './checkpoint';
 import { middleware } from './middleware';
 
 if (process.env.CA_CERT) {
@@ -9,6 +9,7 @@ if (process.env.CA_CERT) {
 }
 
 setupStorageTable();
+ensureIndexes();
 
 const app = express();
 app.use(express.json({ limit: '4mb' }));


### PR DESCRIPTION
## Problem

The delegates list query (e.g. `gnosis.eth`, ordered by `delegatedVotes`) times out and the UI gets a Cloudflare **524** (origin response > 100s). The server is up — trivial queries return in <1s; only the **ordered `delegates` query** hangs.

## Root cause — by the numbers

The `delegates` table is ~99% dead weight:

- **2,044,507** rows total; only **15,290 (0.75%) are live** (current `upper_inf(block_range)`). The other **2,029,217 (99.25%)** are closed historical versions.
- Live `gnosis.eth` rows: **93** — i.e. **0.0045%** of the table (1 in ~22,000).
- `safe.eth` alone = **1,023,844 dead rows (~50% of the whole table)**, sitting in the same global `delegatedVotes` index every ordered query walks.
- Table size **825 MB** (~99% reclaimable); `VACUUM`/autovacuum has run **0 times** (`last_vacuum`/`last_autovacuum` both null).

Checkpoint versions every entity via `block_range` and auto-indexes individual scalar columns, but **nothing covers the `upper_inf(block_range)` "current row" filter**. So `WHERE governance = ? ORDER BY delegatedVotes DESC LIMIT 40` walks the global `delegatedVotes` index and filter-discards over a million dead/non-matching rows to find 40 live ones.

## Fix

1. **Partial index** `(governance, "delegatedVotes" DESC) WHERE upper_inf(block_range)` — contains only the ~15,290 live rows, created idempotently on startup (`ensureIndexes()`). This is the core fix and works even with the existing bloat in place.
2. **Prune** closed row versions after each compute so the table stops growing unbounded. Optional hygiene — the index fixes the timeout on its own.

## Verified on production

`EXPLAIN (ANALYZE, BUFFERS)` on the real prod table (`gnosis.eth`, `first: 40`), before vs after the partial index:

| | Before | After |
|---|---|---|
| Plan | `Index Scan Backward` on global `delegates_delegatedvotes_index` | `Index Scan` on `delegates_live_gov_votes` (`Index Cond: governance = 'gnosis.eth'`) |
| Rows Removed by Filter | **1,616,102** | **0** |
| Buffers | `read=931,990` (~7.3 GB from disk) | `shared hit=4` (~32 KB, **0 disk reads**) |
| Execution Time | **160,490 ms** | **0.138 ms** |

→ **160 s → 0.138 ms (~1,160,000× faster)**, 7.3 GB disk I/O → ~32 KB cache. This also explains the cluster CPU/memory spikes: each timed-out query reads ~7 GB and churns the page cache; retries on the 524 stack them up.

Also reproduced locally on a bloated copy (604,593 rows, 93 live): ordered query 287 ms → 0.054 ms; full UI query timeout → 33 ms; prune 604,593 rows → 93 (0 dead) after one compute. `tsc`, `lint`, `build` all pass.

## Open decisions for reviewers

1. **Index creation** — on app startup (this PR), or run manually on prod? (Already created manually on prod to confirm the fix above.) Startup-code survives a `reset()`; a manual index does not. `CONCURRENTLY` avoids the write lock but can't run in a transaction; plain `CREATE INDEX` is fine here since the only writer is the hourly compute.
2. **Prune** — keep in app (this PR), move to a scheduled DB job (`DELETE WHERE NOT upper_inf(block_range)` + `VACUUM`), or drop it (index alone fixes the 524)?
3. **One-time cleanup** of the existing ~800 MB of dead rows (`DELETE` + `VACUUM`/`pg_repack`)?
4. **Why has autovacuum never run** on this table? Worth investigating independently.
5. **Checkpoint upgrade** (`beta.39` → `beta.70`, incl. [#383](https://github.com/snapshot-labs/checkpoint/pull/383)) — speeds up *writes* (per-entity `loadEntity`/`save` via a `(id, _indexer)` partial index) but does **not** fix this query (wrong columns) and does **not** prune. It's a breaking change (new `_indexer` column, GIST exclude constraint, per-indexer `register`/`Model` API → code changes in `checkpoint.ts`/`compute.ts` + codegen + a reset/migration). Recommend a **separate follow-up PR**, complementary to this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
